### PR TITLE
Fix deprecation errors

### DIFF
--- a/src/layouts/dnd/list.html
+++ b/src/layouts/dnd/list.html
@@ -5,7 +5,7 @@
     {{- .Content -}}
   </section>
   <section class="flex-ns flex-wrap justify-around mt5">
-    {{ $paginator := .Paginate (where .Data.Pages "Dir" "!=" "dnd/hidden/") }}
+    {{ $paginator := .Paginate (where .Pages "File.Dir" "!=" "dnd/hidden/") }}
     {{ range $paginator.Pages }}
     <div class="relative w-100 w-30-l mb4 {{ $.Param "secondary_bg_color_class" | default "bg-white" }}">
       {{- partial "summary.html" . -}}

--- a/src/layouts/partials/summary.html
+++ b/src/layouts/partials/summary.html
@@ -4,7 +4,7 @@
     <!-- <span class="f6 db">{{ humanize .Section }}</span> -->
 
     <h1 class="f3 near-black">
-      <a href="{{ .URL }}" class="link {{ $.Param "secondary_font_color_class" | default "black"}} dim">
+      <a href="{{ .Permalink }}" class="link {{ $.Param "secondary_font_color_class" | default "black"}} dim">
         {{ .Title }}
       </a>
     </h1>


### PR DESCRIPTION
## Description

Fixes build errors caused by deprecated API methods (#16, #17)

Previous functionality was preserved with replacement methods.

## Type of Change

Bug Fix

## Principal Changes

- Replace use of `Page.Dir` with `.File.Dir`
- Replace use of `.URL` with `.PermaLink`

## Testing

This was tested manually. Application of these changes unblocks build errors and preserves existing functionality.
