### PR TITLE
Fix for hugov0.123.3

### DIFF
--- a/src/config.yaml
+++ b/src/config.yaml
@@ -50,26 +50,6 @@ menu:
       url: /dnd/archive
       weight: 6
 
-cascade:
-  - _target:
-      path: /dnd/archive/**
-    family: dnd-archive
-  - _target:
-      path: /dnd/characters/**
-    family: dnd-character
-  - _target:
-      path: /dnd/locations/**
-    family: dnd-location
-  - _target:
-      path: /dnd/notes/**
-    family: dnd-note
-  - _target:
-      path: /dnd/npcs/**
-    family: dnd-npc
-  - _target:
-      path: /dnd/posts/**
-    family: dnd-post
-
 taxonomies:
   character: dnd/ref/characters
   location: dnd/ref/locations

--- a/src/config.yaml
+++ b/src/config.yaml
@@ -52,9 +52,6 @@ menu:
 
 cascade:
   - _target:
-      path: /dnd/_index.md
-    family: dnd-landing
-  - _target:
       path: /dnd/archive/**
     family: dnd-archive
   - _target:

--- a/src/content/dnd/_index.md
+++ b/src/content/dnd/_index.md
@@ -4,6 +4,7 @@ date: 2020-08-22
 description: the sky is grey and tinged with regret
 show_reading_time: true
 title: D&D
+family: dnd-landing
 
 ---
 

--- a/src/content/dnd/archive/_index.md
+++ b/src/content/dnd/archive/_index.md
@@ -1,5 +1,8 @@
 ---
 
+cascade:
+  params:
+    family: dnd-archive
 date: 2020-07-10T09:19:09-07:00
 title: The Archives
 

--- a/src/content/dnd/characters/_index.md
+++ b/src/content/dnd/characters/_index.md
@@ -1,5 +1,8 @@
 ---
 
+cascade:
+  params:
+    family: dnd-character
 title: characters
 
 ---

--- a/src/content/dnd/locations/_index.md
+++ b/src/content/dnd/locations/_index.md
@@ -1,5 +1,8 @@
 ---
 
+cascade:
+  params:
+    family: dnd-location
 title: locations
 
 ---

--- a/src/content/dnd/notes/_index.md
+++ b/src/content/dnd/notes/_index.md
@@ -1,5 +1,8 @@
 ---
 
+cascade:
+  params:
+    family: dnd-note
 title: notes
 
 ---

--- a/src/content/dnd/npcs/_index.md
+++ b/src/content/dnd/npcs/_index.md
@@ -1,5 +1,8 @@
 ---
 
+cascade:
+  params:
+    family: dnd-npc
 title: npcs
 
 ---

--- a/src/content/dnd/posts/_index.md
+++ b/src/content/dnd/posts/_index.md
@@ -1,5 +1,8 @@
 ---
 
+cascade:
+  params:
+    family: dnd-post
 title: posts
 
 ---


### PR DESCRIPTION
## Summary

Layouts in the dnd section of site were broken using Hugo v.0.123.3. These changes begin to address this and allow site to build.

## Details

The dnd [list layout depends upon use of the family param](https://github.com/tlake/static-site/blob/ef55d47be0e8ba6d7bad3f5a635c790e32704573/src/layouts/dnd/list.html#L22), and this was no longer being set properly under latest version of Hugo.

Family param values are now properly set. Also, cascade params are moved to front matter as suggested by Hugo docs for single-language sites.

## Caveats

> [!WARNING]
> While these changes allow site to build on latest Hugo, it appears that the [dnd-related partial](https://github.com/tlake/static-site/blob/main/src/layouts/partials/dnd/dnd-related.html) is not rendering correctly. Further changes are required to fix the behavior with taxonomies used on this site.

## Screenshots

### Hugo v0.123.3 on Current Main Branch

Missing child items in list layout. Only "posts" section included here for brevity.

<img width="1508" alt="Screenshot 2024-02-23 at 11 50 18" src="https://github.com/tlake/static-site/assets/10945369/ef142119-647a-4726-90a7-3d1d7abba2af">

<img width="1509" alt="Screenshot 2024-02-23 at 11 50 45" src="https://github.com/tlake/static-site/assets/10945369/95514e48-39c4-4c74-addc-d22429b7f76c">

### Hugo v0.123.3 on fixForHugov0.123.3

Child items are rendered in list layout.

<img width="1506" alt="Screenshot 2024-02-23 at 11 51 10" src="https://github.com/tlake/static-site/assets/10945369/09a14808-1f07-47ce-8cbf-bae021c389d8">

<img width="1506" alt="Screenshot 2024-02-23 at 11 51 24" src="https://github.com/tlake/static-site/assets/10945369/717fb21f-c67f-4819-ad87-59c48372f55c">


